### PR TITLE
Include UA code for Handbook

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,18 @@
   <meta id="destination" content="{{ content | strip_html }}">
 
   <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-48605964-19', 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('set', 'forceSSL', true);
+    ga('send', 'pageview');
+  </script>
+
+  <script>
     var destination = document.querySelector('#destination').content;
     var hash = window.location.hash;
 


### PR DESCRIPTION
I've included Google Analytics into the URL shortener as part of the spike on 18F/handbook#365